### PR TITLE
added lintr config and project

### DIFF
--- a/.lintr.R
+++ b/.lintr.R
@@ -1,0 +1,86 @@
+
+
+undesirable_functions <-
+  lintr::default_undesirable_functions |>
+  lintr::modify_defaults(
+    
+    # following https://github.com/r-lib/devtools/blob/2aa51ef/.lintr.R:
+    # Base messaging
+    "message" = "use cli::cli_inform()",
+    "warning" = "use cli::cli_warn()",
+    "stop" = "use cli::cli_abort()",
+    # rlang messaging
+    "inform" = "use cli::cli_inform()",
+    "warn" = "use cli::cli_warn()",
+    "abort" = "use cli::cli_abort()",
+    # older cli
+    "cli_alert_danger" = "use cli::cli_inform()",
+    "cli_alert_info" = "use cli::cli_inform()",
+    "cli_alert_success" = "use cli::cli_inform()",
+    "cli_alert_warning" = "use cli::cli_inform()",
+    
+    library = paste(
+      "\nuse `::`, `usethis::use_import_from()`, or `withr::local_package()`",
+      "instead of modifying the global search path.",
+      "\nSee:\n",
+      "<https://r-pkgs.org/code.html#sec-code-r-landscape> and\n",
+      "<https://r-pkgs.org/testing-design.html#sec-testing-design-self-contained>",
+      "\nfor more details."
+    ),
+    
+    structure = NULL,
+    browser = NULL
+    # see https://github.com/r-lib/lintr/pull/2227 and
+    # rebuttal https://github.com/r-lib/lintr/pull/2227#issuecomment-1800302675
+    
+  )
+
+# define snake_case with uppercase acronyms allowed;
+# see https://github.com/r-lib/lintr/issues/2844 for details:
+withr::local_package("rex")
+snake_case_ACROs1 <- rex::rex(
+  start,
+  maybe("."),
+  list(some_of(upper), maybe("s"), zero_or_more(digit)) %or% list(some_of(lower), zero_or_more(digit)),
+  zero_or_more(
+    "_",
+    list(some_of(upper), maybe("s"), zero_or_more(digit)) %or% list(some_of(lower), zero_or_more(digit))
+  ),
+  end
+)
+
+linters <- lintr::linters_with_defaults(
+  return_linter = NULL,
+  trailing_whitespace_linter = NULL,
+  lintr::redundant_equals_linter(),
+  lintr::pipe_consistency_linter(pipe = "|>"),
+  lintr::object_name_linter(
+    regexes = c(snake_case_ACROs1 = snake_case_ACROs1)
+  ),
+  lintr::undesirable_function_linter(
+    fun = undesirable_functions,
+    symbol_is_undesirable = TRUE
+  )
+)
+
+# prevent warnings from lintr::read_settings:
+rm(undesirable_functions)
+rm(snake_case_ACROs1)
+exclusions <- list(
+  `data-raw` = list(
+    pipe_consistency_linter = Inf
+  ),
+  vignettes = list(
+    undesirable_function_linter = Inf
+  ),
+  "inst/examples" = list(
+    undesirable_function_linter = Inf
+  ),
+  "inst/analyses" = list(
+    undesirable_function_linter = Inf
+  ),
+  "tests/testthat.R" = list(
+    undesirable_function_linter = Inf
+  )
+  
+)

--- a/project.Rproj
+++ b/project.Rproj
@@ -1,0 +1,23 @@
+Version: 1.0
+ProjectId: 0e6148a8-f83c-46cf-9b82-065b8295afe7
+
+RestoreWorkspace: No
+SaveWorkspace: No
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes
+LineEndingConversion: Posix
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source
+PackageRoxygenize: rd,collate,namespace


### PR DESCRIPTION
This pull request introduces a new `.lintr.R` configuration file to enforce consistent coding standards and best practices across the codebase, and adds a `project.Rproj` file to standardize RStudio project settings. The primary focus is on improving code quality through customized linting rules and facilitating a reproducible development environment.

**Linting and code quality configuration:**

* Added `.lintr.R` with custom `undesirable_functions` to discourage direct use of base and rlang messaging functions (e.g., `message`, `warning`, `stop`, `inform`, `warn`, `abort`) in favor of `cli` package equivalents, and to discourage use of `library()` for modifying the global search path. Also disables certain linters and configures naming conventions to allow uppercase acronyms in snake_case. Exclusions for specific directories and files are set for some linters.

**Project environment setup:**

* Added `project.Rproj` to define RStudio project settings, including workspace and history behavior, code formatting preferences, build options, and encoding, ensuring a consistent development environment for all contributors.