### PR TITLE
adding pr previews

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -36,6 +36,10 @@ on:
 
 name: pkgdown
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   pkgdown-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request significantly refactors the `.github/workflows/pkgdown.yaml` workflow to support more robust and flexible pkgdown documentation deployment for pull requests, tags, and main branch updates. The new workflow enables PR previews, tagged version deployments, and automatic cleanup of PR preview sites when PRs are closed. It also improves event handling, documentation subdirectory management, and notification of deployments.

**Workflow event handling and deployment logic:**

* Expanded event triggers to handle PRs (with specific actions and paths), version tags (excluding dev tags), and manual dispatches, allowing for more granular and targeted documentation builds and deployments.
* Added logic to deploy documentation to subdirectories based on event type: PRs deploy to `preview/pr<number>`, tags to `<tag>`, and dispatches to the provided tag input.

**PR preview and cleanup management:**

* Introduced a dedicated job (`pkgdown-clean`) to automatically remove PR preview documentation when a PR is closed, keeping the documentation site tidy.
* Added notification steps to comment on PRs with deployment URLs and cleanup status using the `hasura/comment-progress` GitHub Action.

**Improvements to setup and deployment steps:**

* Updated steps to configure git, set up Quarto, and install dependencies required for pkgdown and Quarto integration, ensuring the workflow